### PR TITLE
Some small fixes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -190,9 +190,6 @@ class CVEScannerCharm(CharmBase):
             event.fail(f"Configuration error: {secret_error}")
             return
 
-        # Set status to indicate scan is running
-        self.unit.status = MaintenanceStatus("Running CVE scan")
-
         try:
             # Run the scan
             result = self.cve_scanner.run_scan(

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,6 @@
 """Configuration module for CVE Scanner Charm."""
 
 from enum import Enum
-from pathlib import Path
 from typing import Dict, Optional
 
 from pydantic import BaseModel, Field, SecretStr, validator
@@ -16,24 +15,12 @@ class LogLevel(str, Enum):
     ERROR = "ERROR"
 
 
-class CVEExporterMetadata(BaseModel):
-    """Settings for CVE Scanner exporter service."""
-
-    name: str = "cve-scanner-exporter"
-    snap_name: str = "cve-scanner"
-    service_name: str = "snap.cve-scanner.cve-exporter"
-    snap_service_name: str = "cve-exporter"
-    config_path: Path = Path("/etc/cve-scanner-config.yaml")
-
-    @property
-    def systemd_override_dir(self) -> str:
-        """Get systemd override directory path for service configuration."""
-        return f"/etc/systemd/system/{self.service_name}.service.d"
-
-    @property
-    def systemd_service_unit(self) -> str:
-        """Get full systemd service unit name."""
-        return f"{self.service_name}.service"
+# CVE Scanner exporter service constants
+SNAP_NAME = "cve-scanner"
+SNAP_SERVICE_NAME = "cve-exporter"
+SERVICE_NAME = f"snap.{SNAP_NAME}.{SNAP_SERVICE_NAME}"
+SYSTEMD_OVERRIDE_DIR = f"/etc/systemd/system/{SERVICE_NAME}.service.d"
+STORAGE_DIR = f"/var/snap/{SNAP_NAME}/common"
 
 
 class CVEScannerConfig(BaseModel):
@@ -143,7 +130,7 @@ class CVEScannerConfig(BaseModel):
 
     def get_ca_cert_file_path(self) -> str:
         """Get the path where the CA certificate should be stored on the charm machine."""
-        return "/var/snap/cve-scanner/common/landscape-ca.pem"
+        return f"{STORAGE_DIR}/landscape-ca.pem"
 
     def get_ca_cert_content(self) -> Optional[str]:
         """Get CA certificate content if available.
@@ -188,7 +175,3 @@ class CVEScannerConfig(BaseModel):
             env_vars["LANDSCAPE_API_SSL_CA_FILE"] = self.get_ca_cert_file_path()
 
         return env_vars
-
-
-# Global metadata instance
-CVE_EXPORTER_METADATA = CVEExporterMetadata()

--- a/src/cve_scanner.py
+++ b/src/cve_scanner.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 from typing import Any, Dict, List
 
-from config import CVEScannerConfig
+from config import SNAP_NAME, STORAGE_DIR, CVEScannerConfig
 from utils import SecretManager
 
 logger = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class CVEScanner:
     """CVE scanner for running scanning action using the cve-scanner snap."""
 
-    def __init__(self, snap_name: str = "cve-scanner"):
+    def __init__(self, snap_name: str = SNAP_NAME):
         """Initialize the CVE scanner.
 
         Args:
@@ -121,7 +121,7 @@ class CVEScanner:
             cmd.append("--no-pdf")
 
         # Set output directory for charm-initiated scans
-        cmd.extend(["--output-dir", "/var/snap/cve-scanner/common/"])
+        cmd.extend(["--output-dir", STORAGE_DIR])
 
         return cmd
 

--- a/src/snap_helpers.py
+++ b/src/snap_helpers.py
@@ -9,7 +9,12 @@ from charms.operator_libs_linux.v1 import systemd
 from charms.operator_libs_linux.v2 import snap
 from ops.charm import CharmBase
 
-from config import CVE_EXPORTER_METADATA, CVEScannerConfig
+from config import (
+    SNAP_NAME,
+    SNAP_SERVICE_NAME,
+    SYSTEMD_OVERRIDE_DIR,
+    CVEScannerConfig,
+)
 from utils import FileManager, SecretManager
 
 logger = logging.getLogger(__name__)
@@ -36,7 +41,7 @@ class CVEScannerSnapManager:
         Args:
             snap_resource_path: Path to the snap resource file if installing from local file.
         """
-        self.snap_name = CVE_EXPORTER_METADATA.snap_name
+        self.snap_name = SNAP_NAME
         self.snap_resource_path = snap_resource_path
 
     @property
@@ -139,7 +144,7 @@ class CVEScannerSnapManager:
 
         logger.info("Starting CVE exporter daemon service")
         try:
-            self._snap_client.start([CVE_EXPORTER_METADATA.snap_service_name], enable=True)
+            self._snap_client.start([SNAP_SERVICE_NAME], enable=True)
         except snap.SnapError as err:
             raise SnapServiceError(f"Failed to start CVE exporter daemon service: {err}") from err
 
@@ -157,7 +162,7 @@ class CVEScannerSnapManager:
 
         logger.info("Stopping CVE exporter daemon service")
         try:
-            self._snap_client.stop([CVE_EXPORTER_METADATA.snap_service_name], disable=True)
+            self._snap_client.stop([SNAP_SERVICE_NAME], disable=True)
         except snap.SnapError as err:
             raise SnapServiceError(f"Failed to stop CVE exporter daemon service: {err}") from err
 
@@ -174,7 +179,7 @@ class CVEScannerSnapManager:
 
         logger.info("Restarting CVE exporter daemon service")
         try:
-            self._snap_client.restart([CVE_EXPORTER_METADATA.snap_service_name], reload=True)
+            self._snap_client.restart([SNAP_SERVICE_NAME], reload=True)
         except snap.SnapError as err:
             raise SnapServiceError(
                 f"Failed to restart CVE exporter daemon service: {err}"
@@ -200,7 +205,7 @@ class CVEScannerSnapManager:
 
         try:
             services = self._snap_client.services
-            service_name = CVE_EXPORTER_METADATA.snap_service_name
+            service_name = SNAP_SERVICE_NAME
             if service_name in services:
                 return services[service_name].get("active", False)
             return False
@@ -274,7 +279,7 @@ class CVEScannerSnapManager:
         logger.info("Configuring environment variables for CVE exporter service")
         try:
             # Create systemd override for environment variables
-            override_dir = CVE_EXPORTER_METADATA.systemd_override_dir
+            override_dir = SYSTEMD_OVERRIDE_DIR
             os.makedirs(override_dir, exist_ok=True)
 
             override_file = f"{override_dir}/environment.conf"


### PR DESCRIPTION
Some small fixes:
- Correct the name of the snap exporter service.
- Change the place to store CA cert file and pdf output to adhere to snap permission
- Change `landscape_ca_cert_content` to `landscape_ca_cert`: somehow the former doesn't work with `CharmBase.load_config` even it has a correct Pydantic alias. So just simply change this variable to match the name in config.yaml.