### PR TITLE
Add rules for exit codes

### DIFF
--- a/src/prometheus_alert_rules/cve_scanner.yaml
+++ b/src/prometheus_alert_rules/cve_scanner.yaml
@@ -73,6 +73,34 @@ groups:
           summary: "CVE scan failed on server {{ $labels.node }}"
           description: "CVE scan has failed on server {{ $labels.node }}"
 
+      - alert: CVEScannerGeneralError
+        expr: cve_scanner_exit_code == 127
+        for: 5m
+        labels:
+          severity: critical
+          node: "{{ $labels.node }}"
+        annotations:
+          summary: "OSV scanner general error"
+          description: |
+            OSV scanner returned a general error on {{ $labels.node }}.
+            This could be a temporal issue with osv-scanner.
+            Try restarting the cve-scanner.exporter service: 'sudo snap restart cve-scanner.cve-exporter'
+            Reference: https://google.github.io/osv-scanner/output/#return-codes
+
+
+      - alert: CVEScannerNoPackagesFound
+        expr: cve_scanner_exit_code == 128
+        for: 5m
+        labels:
+          severity: critical
+          node: "{{ $labels.node }}"
+        annotations:
+          summary: "CVE scanner found no packages on {{ $labels.node }}"
+          description: |
+            OSV scanner returned with no packages found on {{ $labels.node }}. This indicates scanning format not picking up any files to scan.
+            Please open an issue at https://github.com/canonical/cve-scanner/issues
+            Reference: https://google.github.io/osv-scanner/output/#return-codes
+
       - alert: CVEScanCollectorDown
         expr: cve_collector_ready == 0
         for: 10m


### PR DESCRIPTION
Add alerts when the `osv-scanner` return failed outputs. Requires the [PR](https://github.com/canonical/cve-scanner/pull/9) to expose the metric being merged first.

Closes #8 



