### PR TITLE
Fix life-cycle behavior

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -125,6 +125,10 @@ class CVEScannerCharm(CharmBase):
 
     def _on_config_changed(self, event):
         """Handle the config-changed event."""
+        if not self.cve_snap_manager.is_installed():
+            self.unit.status = BlockedStatus("CVE scanner snap not installed")
+            return
+
         self.unit.status = MaintenanceStatus("Configuring CVE scanner")
 
         # Get and validate configuration

--- a/src/snap_helpers.py
+++ b/src/snap_helpers.py
@@ -60,10 +60,6 @@ class CVEScannerSnapManager:
         Raises:
             SnapInstallationError: If installation fails.
         """
-        if self.is_installed():
-            logger.info("CVE scanner snap is already installed")
-            return
-
         has_resource = self.snap_resource_path and self.snap_resource_path.exists()
 
         # Try resource installation if available


### PR DESCRIPTION
This PR fixes 2 below issues:
1. If setting config when the snap resource is not attached, the charm will be in error status because the config-changed hook will be triggered, trying to start/restart the snap service (which doesn't exist yet). 
-> Fix by adding into config-changed hook the condition to block the charm when the snap resource is not installed. 

2. Consider the charm in an active state (a snap resource is already installed and configured), and we now want to use a different snap resource. It is not possible because the current `is_installed` check in `install_snap` will skip the re-installation when `juju attach-resource` the newer snap.
-> Fix by removing this check. The snap installation is already idempotent by design.  