### PR TITLE
Replace grafana-agent by otel-collector in metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,7 +8,7 @@ summary: Principal charm for CVE vulnerability scanning and monitoring.
 description: |
   Principal charm for CVE vulnerability scanning that charms the cve-scanner snap.
   This charm runs CVE scanning as a Prometheus exporter service and integrates with
-  Landscape for centralized monitoring. It can be related with grafana-agent via
+  Landscape for centralized monitoring. It can be related with opentelemetry-collector via
   cos-agent relation to send metrics and alert rules to Canonical Observability Stack (COS).
 
 website: https://github.com/canonical/cve-scanner


### PR DESCRIPTION
Closes #30 
Mention `opentelemetry-collector` instead of `grafana-agent`.
Test by replacing directly:
 
<img width="1206" height="425" alt="image" src="https://github.com/user-attachments/assets/9f8b672c-f946-48dd-a423-3d6b94f57858" />

The rules are forwarded correctly to COS lite by otel-collector:
<img width="1589" height="815" alt="image" src="https://github.com/user-attachments/assets/f9dace09-0a6c-4a74-afcb-edbcc8c76b5d" />
<img width="1509" height="322" alt="image" src="https://github.com/user-attachments/assets/f7d3a7d1-aaa2-441a-aebd-85be4f2c7285" />
