### PR TITLE
Change jira epic & add owners

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -27,7 +27,7 @@ settings:
   add_gh_comment: true
 
   # (Optional) (Default: None) Parent Epic key to link the issue to
-  epic_key: SOLENG-1629
+  epic_key: SOLENG-1990
 
   # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
   # If label on the issue is not in specified list, this issue will be created as a Bug

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# This file is centrally managed as a template file in https://github.com/canonical/solutions-engineering-automation
+# To update the file:
+# - Edit it in the canonical/solutions-engineering-automation repository.
+# - Open a PR with the changes.
+# - When the PR merges, the soleng-terraform bot will open a PR to the target repositories with the changes.
+#
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, @canonical/soleng-reviewers will be requested for
+# review when someone opens a pull request.
+*    @canonical/soleng-reviewers


### PR DESCRIPTION
Issues will be link to the [backlog](https://warthogs.atlassian.net/browse/SOLENG-1990) instead of the v1 epic.
Add codeowners