### PR TITLE
feat: support proxy configs from juju model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ ops >= 2.2.0
 pydantic < 2
 jinja2
 requests
+charms.proxylib

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,7 +20,7 @@ from snap_helpers import (
     SnapInstallationError,
     SnapServiceError,
 )
-from utils import SecretManager
+from utils import InvalidProxyError, SecretManager, get_proxy_env
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +154,10 @@ class CVEScannerCharm(CharmBase):
             # Configure CIS service if enabled
             self.cis_service.configure_cis_service(config.security_profile_id)
 
+        except InvalidProxyError as err:
+            self.unit.status = BlockedStatus(f"Invalid proxy configuration: {err}")
+            return
+
         except SnapConfigurationError as err:
             logger.error("Fail to configure snap service: %s", err)
             raise
@@ -212,6 +216,13 @@ class CVEScannerCharm(CharmBase):
         # Validate secret-dependent configuration
         if secret_error := self._validate_secrets():
             event.fail(f"Configuration error: {secret_error}")
+            return
+
+        # Fail fast on malformed proxy
+        try:
+            get_proxy_env()
+        except InvalidProxyError as err:
+            event.fail(f"Invalid proxy configuration: {err}")
             return
 
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,7 +20,7 @@ from snap_helpers import (
     SnapInstallationError,
     SnapServiceError,
 )
-from utils import InvalidProxyError, SecretManager, get_proxy_env
+from utils import InvalidProxyError, SecretManager
 
 logger = logging.getLogger(__name__)
 
@@ -216,13 +216,6 @@ class CVEScannerCharm(CharmBase):
         # Validate secret-dependent configuration
         if secret_error := self._validate_secrets():
             event.fail(f"Configuration error: {secret_error}")
-            return
-
-        # Fail fast on malformed proxy
-        try:
-            get_proxy_env()
-        except InvalidProxyError as err:
-            event.fail(f"Invalid proxy configuration: {err}")
             return
 
         try:

--- a/src/cve_scanner.py
+++ b/src/cve_scanner.py
@@ -6,7 +6,7 @@ import subprocess
 from typing import Any, Dict, List
 
 from config import SNAP_NAME, STORAGE_DIR, CVEScannerConfig
-from utils import SecretManager
+from utils import SecretManager, get_proxy_env
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +142,9 @@ class CVEScanner:
         secrets = SecretManager.get_landscape_secrets(charm)
         scanner_env = config.build_environment_vars(charm.model.app.name, secrets)
         env.update(scanner_env)
+
+        # Add proxy environment variables if set from juju model-config
+        env.update(get_proxy_env())
 
         return env
 

--- a/src/cve_scanner.py
+++ b/src/cve_scanner.py
@@ -6,7 +6,7 @@ import subprocess
 from typing import Any, Dict, List
 
 from config import SNAP_NAME, STORAGE_DIR, CVEScannerConfig
-from utils import SecretManager, get_proxy_env
+from utils import InvalidProxyError, SecretManager, get_proxy_env
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +82,13 @@ class CVEScanner:
                 "success": False,
                 "error": f"Scan timed out after {timeout} seconds",
                 "timeout": True,
+                "command": " ".join(cmd) if "cmd" in locals() else "unknown",
+            }
+        except InvalidProxyError as err:
+            logger.error("Invalid proxy configuration: %s", err)
+            return {
+                "success": False,
+                "error": f"Invalid proxy configuration: {err}",
                 "command": " ".join(cmd) if "cmd" in locals() else "unknown",
             }
         except Exception as err:

--- a/src/snap_helpers.py
+++ b/src/snap_helpers.py
@@ -15,7 +15,7 @@ from config import (
     SYSTEMD_OVERRIDE_DIR,
     CVEScannerConfig,
 )
-from utils import FileManager, SecretManager
+from utils import FileManager, SecretManager, get_proxy_env
 
 logger = logging.getLogger(__name__)
 
@@ -271,6 +271,9 @@ class CVEScannerSnapManager:
         """
         secrets = SecretManager.get_landscape_secrets(charm)
         env_vars = config.build_environment_vars(charm.model.app.name, secrets)
+
+        # Add proxy environment variables if set from juju model-config
+        env_vars.update(get_proxy_env())
 
         logger.info("Configuring environment variables for CVE exporter service")
         try:

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 from typing import Dict, Optional
 
+from charms import proxylib
 from ops.charm import CharmBase
 from ops.model import ModelError, SecretNotFoundError
 
@@ -170,3 +171,25 @@ def create_security_profile_client() -> SecurityProfilesClient:
     landscape_config = get_landscape_config_from_env()
     api_client = LandscapeV2Client(landscape_config)
     return SecurityProfilesClient(api_client)
+
+
+class InvalidProxyError(Exception):
+    """Raised when Juju model proxy is configured but the URL is malformed."""
+
+
+def get_proxy_env() -> Dict[str, str]:
+    """Return Juju model proxy settings for injection into service/subprocess envs.
+
+    Returns:
+        Dictionary of proxy env vars (lowercase + uppercase variants).
+        Empty dict if no proxy is configured.
+
+    Raises:
+        InvalidProxyError: If proxy is configured but the URL is malformed
+            (e.g., missing scheme). Caller should set BlockedStatus / fail
+            the action so the operator sees the misconfiguration.
+    """
+    proxy_env = proxylib.environ(enabled=True)
+    if proxy_env.error:
+        raise InvalidProxyError(str(proxy_env.error))
+    return {k: v for k, v in proxy_env.items() if v}


### PR DESCRIPTION
The charm will pick up the proxy settings from juju model-config for the exporter service and the action, using [charms.proxylib](https://github.com/canonical/charms.proxylib)

For now I cannot find any hook fired for changes in model-config level - so to pick up the change, need to manually fire a config-changed hook. 

Could be the resolution to https://github.com/canonical/cve-scanner-operator/issues/39