### PR TITLE
fix: correct scan error output

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -224,22 +224,21 @@ class CVEScannerCharm(CharmBase):
                 timeout=config.scan_timeout,
             )
 
-            if not result["success"]:
-                error_msg = result.get("error", "Unknown error")
-                event.fail(f"CVE scan failed: {error_msg}")
-                logger.error("CVE scan action failed: %s", error_msg)
-                return
-
-            # Extract key information for action results
-            action_results = {
-                "success": True,
-                "message": "CVE scan completed successfully",
-            }
-
-            # Add metrics if available
+            action_results = {}
             if "metrics" in result:
                 action_results["metrics"] = result["metrics"]
 
+            if not result["success"]:
+                error_msg = result.get(
+                    "error",
+                    f"Scanner exited with code {result.get('returncode', 'unknown')}",
+                )
+                event.set_results(action_results)
+                event.fail(error_msg)
+                logger.error("CVE scan action failed: %s", error_msg)
+                return
+
+            action_results["message"] = "CVE scan completed successfully"
             event.set_results(action_results)
             logger.info("CVE scan action completed successfully")
 

--- a/src/cve_scanner.py
+++ b/src/cve_scanner.py
@@ -67,12 +67,19 @@ class CVEScanner:
                 "command": " ".join(cmd),
             }
 
+            if result.stdout:
+                scan_result["metrics"] = self._extract_metrics_from_output(result.stdout)
+
             if result.returncode == 0:
                 logger.info("CVE scan completed successfully")
-                scan_result["metrics"] = self._extract_metrics_from_output(result.stdout)
             else:
                 logger.error("CVE scan failed with return code %d", result.returncode)
                 logger.error("stderr: %s", result.stderr)
+                error_lines = [line for line in result.stderr.splitlines() if " ERROR " in line]
+                if error_lines:
+                    scan_result["error"] = error_lines[-1].split(" ERROR ", 1)[-1].strip()
+                else:
+                    scan_result["error"] = f"Scanner exited with code {result.returncode}"
 
             return scan_result
 


### PR DESCRIPTION
Correct the output message from scan-now action when a scan failure happens.

This fix is a follow-up for this corresponding fix in the snap: https://github.com/canonical/cve-scanner/pull/27

Part of the fix for https://github.com/canonical/cve-scanner-operator/issues/39

Output from a failed scan now will be: 

```
~$ juju run cve-scanner/0 scan-now servers="node-alpha" pdf-output=false
Running operation 65 with 1 task
  - task 66 on unit-cve-scanner-0

Waiting for task 66...
Action id 66 failed: CVE scan failed: One or more node scans had unhealthy execution status (check cve_scan_success and cve_scanner_exit_code metrics)
metrics: |-
  # HELP cve_count Number of CVE vulnerabilities by score
  # TYPE cve_count gauge
  cve_count{node="node-alpha",score="critical"} 0.0
  cve_count{node="node-alpha",score="high"} 0.0
  cve_count{node="node-alpha",score="medium"} 0.0
  cve_count{node="node-alpha",score="low"} 0.0
  cve_count{node="node-alpha",score="unknown"} 0.0
  # HELP cve_scan_success CVE scan success indicator (1=healthy scan, 0=unhealthy)
  # TYPE cve_scan_success gauge
  cve_scan_success{node="node-alpha"} 0.0
  # HELP cve_scanner_exit_code OSV scanner exit code (0/1=success, other indicates error)
  # TYPE cve_scanner_exit_code gauge
  cve_scanner_exit_code{node="node-alpha"} 127.0
```
