### PR TITLE
chore: remove ca-cert file if unset config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -180,7 +180,7 @@ class CVEScannerConfig(BaseModel):
             env_vars["LANDSCAPE_API_SECRET"] = secrets["landscape_api_secret"]
 
         # Add CA cert file path if certificate content was provided
-        if self.landscape_ca_cert.get_secret_value().strip():
+        if self.get_ca_cert_content():
             env_vars["LANDSCAPE_API_SSL_CA_FILE"] = self.get_ca_cert_file_path()
 
         return env_vars

--- a/src/snap_helpers.py
+++ b/src/snap_helpers.py
@@ -263,7 +263,7 @@ class CVEScannerSnapManager:
             return
 
         # If no certificate content provided, remove existing CA cert file
-        if ca_cert_path.exists() and not FileManager.remove_file(ca_cert_path):
+        if not FileManager.remove_file(ca_cert_path):
             logger.warning(
                 "Failed to remove existing CA certificate file at %s, but can continue without it",
                 config.get_ca_cert_file_path(),

--- a/src/snap_helpers.py
+++ b/src/snap_helpers.py
@@ -258,6 +258,14 @@ class CVEScannerSnapManager:
         if cert_content := config.get_ca_cert_content():
             if not FileManager.write_to_file(cert_content, Path(config.get_ca_cert_file_path())):
                 raise SnapConfigurationError("Failed to write CA certificate file")
+            return
+
+        # If no certificate content provided, remove existing CA cert file
+        if not FileManager.remove_file(Path(config.get_ca_cert_file_path())):
+            logger.warning(
+                "Failed to remove existing CA certificate file at %s, but can continue without it",
+                config.get_ca_cert_file_path(),
+            )
 
     def _configure_environment(self, config: CVEScannerConfig, charm: CharmBase) -> None:
         """Configure snap environment variables.

--- a/src/snap_helpers.py
+++ b/src/snap_helpers.py
@@ -255,13 +255,15 @@ class CVEScannerSnapManager:
         Raises:
             SnapConfigurationError: If CA certificate setup fails.
         """
+        ca_cert_path = Path(config.get_ca_cert_file_path())
+
         if cert_content := config.get_ca_cert_content():
-            if not FileManager.write_to_file(cert_content, Path(config.get_ca_cert_file_path())):
+            if not FileManager.write_to_file(cert_content, ca_cert_path):
                 raise SnapConfigurationError("Failed to write CA certificate file")
             return
 
         # If no certificate content provided, remove existing CA cert file
-        if not FileManager.remove_file(Path(config.get_ca_cert_file_path())):
+        if ca_cert_path.exists() and not FileManager.remove_file(ca_cert_path):
             logger.warning(
                 "Failed to remove existing CA certificate file at %s, but can continue without it",
                 config.get_ca_cert_file_path(),

--- a/src/utils.py
+++ b/src/utils.py
@@ -53,8 +53,9 @@ class FileManager:
             True if file was removed successfully, False otherwise.
         """
         try:
-            file_path.unlink(missing_ok=True)
-            logger.info(f"Removed file {file_path}")
+            if file_path.exists():
+                file_path.unlink()
+                logger.info(f"Removed file {file_path}")
             return True
 
         except Exception as e:


### PR DESCRIPTION
If the landscape-ca-cert config is unset, currently only the corresponding env var is removed, but the stale file is not removed.

Fix #38 
