### PR TITLE
Support offline scanning

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -32,6 +32,15 @@ resources:
       This snap provides both CLI scanning and daemon exporter functionality.
     filename: cve-scanner.snap
 
+  osv-db:
+    type: file
+    description: |
+      Pre-downloaded OSV vulnerability database for offline scanning.
+      Must be a .tar.gz archive with the following internal structure:
+        osv-scanner/
+          Ubuntu/all.zip
+    filename: osv-db.tar.gz
+
 provides:
   cos-agent:
     interface: cos_agent
@@ -80,6 +89,20 @@ config:
       default: 300
       description: |
         Timeout for OSV scanner operations in seconds.
+
+    osv-offline:
+      type: boolean
+      default: false
+      description: |
+        Enable offline scanning mode.
+        When true, osv-scanner runs with --offline flag and does not contact
+        the OSV API. Requires the osv-db resource to be attached.
+
+    scan-threads:
+      type: int
+      default: 4
+      description: |
+        Number of parallel threads for OSV scanning.
 
     # Metrics & Exporter Configuration
     cve-exporter-port:

--- a/src/charm.py
+++ b/src/charm.py
@@ -81,6 +81,22 @@ class CVEScannerCharm(CharmBase):
 
         return None
 
+    def _get_osv_db_resource_path(self) -> Optional[Path]:
+        """Get the path to the OSV database resource.
+
+        Returns:
+            Path to the osv-db resource file, or None if not available.
+        """
+        try:
+            resource = self.model.resources.fetch("osv-db")
+            resource_path = Path(resource)
+            if resource_path.stat().st_size != 0:
+                return resource_path
+            logger.info("osv-db resource is empty (placeholder file)")
+        except (NameError, ModelError) as err:
+            logger.warning("Failed to fetch osv-db resource: %s", err)
+        return None
+
     def _get_config(self) -> CVEScannerConfig:
         """Get the current charm configuration with auto validation.
 
@@ -123,6 +139,14 @@ class CVEScannerCharm(CharmBase):
             logger.error("Snap installation blocked: %s", err)
             return
 
+        try:
+            osv_db_path = self._get_osv_db_resource_path()
+            self.cve_snap_manager.extract_osv_db_resource(osv_db_path)
+        except SnapConfigurationError as err:
+            self.unit.status = BlockedStatus(f"Invalid osv-db resource: {err}")
+            logger.error("osv-db extraction failed: %s", err)
+            return
+
     def _on_config_changed(self, event):
         """Handle the config-changed event."""
         if not self.cve_snap_manager.is_installed():
@@ -137,6 +161,13 @@ class CVEScannerCharm(CharmBase):
         # Validate secret-dependent configuration
         if secret_error := self._validate_secrets():
             self.unit.status = BlockedStatus(secret_error)
+            return
+
+        if config.osv_offline and config.get_osv_db_path() is None:
+            self.unit.status = BlockedStatus(
+                "offline mode requires osv-db resource; "
+                "attach with: juju attach-resource cve-scanner osv-db=<path>"
+            )
             return
 
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
-from ops.charm import ActionEvent, CharmBase
+from ops.charm import ActionEvent, CharmBase, CollectStatusEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError
 
@@ -43,7 +43,7 @@ class CVEScannerCharm(CharmBase):
         self.framework.observe(self.on.install, self._on_install_or_upgrade)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.remove, self._on_remove)
-        self.framework.observe(self.on.update_status, self._on_update_status)
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         self.framework.observe(self.on.upgrade_charm, self._on_install_or_upgrade)
 
         # Register action handlers
@@ -123,6 +123,41 @@ class CVEScannerCharm(CharmBase):
 
         return None
 
+    def _check_unit_health(self) -> Optional[str]:
+        """Validate unit prerequisites and return a BlockedStatus message if any check fails.
+
+        Checks snap installation, secrets, and offline-mode configuration.
+        If charm config is invalid, the method will set charm to BlockedStatus via load_config().
+        Otherwise it will return a usable message for BlockedStatus or None if all checks pass.
+
+        Returns:
+            A message for BlockedStatus if a prerequisite is unmet, else None.
+        """
+        if not self.cve_snap_manager.is_installed():
+            return "CVE scanner snap not installed"
+        if secret_error := self._validate_secrets():
+            return secret_error
+        config = self._get_config()
+        if config.osv_offline and config.get_osv_db_path() is None:
+            return (
+                "offline mode requires osv-db resource; "
+                "attach with: juju attach-resource cve-scanner osv-db=<path>"
+            )
+        return None
+
+    def _on_collect_unit_status(self, event: CollectStatusEvent) -> None:
+        """Determine unit status holistically at the end of every hook."""
+        if blocked := self._check_unit_health():
+            event.add_status(BlockedStatus(blocked))
+            return
+
+        status_message = "CVE scanner active"
+        if self.cis_service.check_active():
+            status_message += " (CIS reporting enabled)"
+        else:
+            status_message += " (CIS reporting inactive)"
+        event.add_status(ActiveStatus(status_message))
+
     def _on_install_or_upgrade(self, event):
         """Handle the install event."""
         self.unit.status = MaintenanceStatus("Installing CVE scanner snap")
@@ -149,26 +184,13 @@ class CVEScannerCharm(CharmBase):
 
     def _on_config_changed(self, event):
         """Handle the config-changed event."""
-        if not self.cve_snap_manager.is_installed():
-            self.unit.status = BlockedStatus("CVE scanner snap not installed")
+        if blocked := self._check_unit_health():
+            self.unit.status = BlockedStatus(blocked)
             return
 
         self.unit.status = MaintenanceStatus("Configuring CVE scanner")
 
-        # Get and validate configuration
         config = self._get_config()
-
-        # Validate secret-dependent configuration
-        if secret_error := self._validate_secrets():
-            self.unit.status = BlockedStatus(secret_error)
-            return
-
-        if config.osv_offline and config.get_osv_db_path() is None:
-            self.unit.status = BlockedStatus(
-                "offline mode requires osv-db resource; "
-                "attach with: juju attach-resource cve-scanner osv-db=<path>"
-            )
-            return
 
         try:
             # Configure the service
@@ -201,8 +223,6 @@ class CVEScannerCharm(CharmBase):
             logger.error("Failed to configure CIS service: %s", err)
             raise
 
-        self.unit.status = ActiveStatus("CVE scanner ready")
-
     def _on_remove(self, event):
         """Handle the remove event."""
         self.unit.status = MaintenanceStatus("Removing CVE scanner")
@@ -212,28 +232,6 @@ class CVEScannerCharm(CharmBase):
 
         self.cve_snap_manager.uninstall_snap()
         logger.info("CVE scanner snap removed successfully")
-
-    def _on_update_status(self, event):
-        """Handle the update-status event."""
-        if not self.cve_snap_manager.is_installed():
-            self.unit.status = BlockedStatus("CVE scanner snap not installed")
-            return
-
-        # Validate configuration
-        _ = self._get_config()
-
-        # Validate secret-dependent configuration
-        if secret_error := self._validate_secrets():
-            self.unit.status = BlockedStatus(f"Configuration error: {secret_error}")
-            return
-
-        status_message = "CVE scanner active"
-        if self.cis_service.check_active():
-            status_message += " (CIS reporting enabled)"
-        else:
-            status_message += " (CIS reporting inactive)"
-
-        self.unit.status = ActiveStatus(status_message)
 
     def _on_scan_now_action(self, event: ActionEvent):
         """Handle the scan-now action."""
@@ -249,37 +247,31 @@ class CVEScannerCharm(CharmBase):
             event.fail(f"Configuration error: {secret_error}")
             return
 
-        try:
-            # Run the scan
-            result = self.cve_scanner.run_scan(
-                config=config,
-                charm=self,
-                servers=servers,
-                pdf_output=pdf_output,
-                timeout=config.scan_timeout,
+        result = self.cve_scanner.run_scan(
+            config=config,
+            charm=self,
+            servers=servers,
+            pdf_output=pdf_output,
+            timeout=config.scan_timeout,
+        )
+
+        action_results = {}
+        if "metrics" in result:
+            action_results["metrics"] = result["metrics"]
+
+        if not result["success"]:
+            error_msg = result.get(
+                "error",
+                f"Scanner exited with code {result.get('returncode', 'unknown')}",
             )
-
-            action_results = {}
-            if "metrics" in result:
-                action_results["metrics"] = result["metrics"]
-
-            if not result["success"]:
-                error_msg = result.get(
-                    "error",
-                    f"Scanner exited with code {result.get('returncode', 'unknown')}",
-                )
-                event.set_results(action_results)
-                event.fail(error_msg)
-                logger.error("CVE scan action failed: %s", error_msg)
-                return
-
-            action_results["message"] = "CVE scan completed successfully"
             event.set_results(action_results)
-            logger.info("CVE scan action completed successfully")
+            event.fail(error_msg)
+            logger.error("CVE scan action failed: %s", error_msg)
+            return
 
-        finally:
-            # Restore status
-            self._on_update_status(event)
+        action_results["message"] = "CVE scan completed successfully"
+        event.set_results(action_results)
+        logger.info("CVE scan action completed successfully")
 
     def _scrape_config(self) -> list[dict]:
         """Generate scrape configuration for COS agent.

--- a/src/config.py
+++ b/src/config.py
@@ -71,6 +71,19 @@ class CVEScannerConfig(BaseModel):
         description="Log level for the CVE scanner service",
     )
 
+    osv_offline: bool = Field(
+        default=False,
+        alias="osv-offline",
+        description="Enable offline scanning mode",
+    )
+    scan_threads: int = Field(
+        default=4,
+        ge=1,
+        le=32,
+        alias="scan-threads",
+        description="Number of parallel threads for OSV scanning",
+    )
+
     # CIS Security Profile Reporting
     security_profile_id: int = Field(
         default=0,
@@ -150,6 +163,16 @@ class CVEScannerConfig(BaseModel):
         content = self.landscape_ca_cert.get_secret_value().strip()
         return content if content else None
 
+    def get_osv_db_path(self) -> Optional[str]:
+        """Return STORAGE_DIR if offline mode is enabled and the OSV DB directory exists.
+
+        Returns:
+            STORAGE_DIR string when osv-offline=True and DB is present, None otherwise.
+        """
+        if self.osv_offline and (Path(STORAGE_DIR) / "osv-scanner").exists():
+            return STORAGE_DIR
+        return None
+
     def build_environment_vars(
         self, app_name: str, secrets: Dict[str, Optional[str]]
     ) -> Dict[str, str]:
@@ -170,6 +193,8 @@ class CVEScannerConfig(BaseModel):
             "NODE_NAME": app_name,
             "PORT": str(self.cve_exporter_port),
             "SCAN_INTERVAL": str(self.scan_interval),  # Already in seconds
+            "OSV_OFFLINE": "true" if self.osv_offline else "false",
+            "SCAN_THREADS": str(self.scan_threads),
         }
 
         # Add Landscape credentials if available
@@ -182,6 +207,9 @@ class CVEScannerConfig(BaseModel):
         # Add CA cert file path if certificate content was provided
         if self.get_ca_cert_content():
             env_vars["LANDSCAPE_API_SSL_CA_FILE"] = self.get_ca_cert_file_path()
+
+        if osv_db_path := self.get_osv_db_path():
+            env_vars["OSV_DB_PATH"] = osv_db_path
 
         return env_vars
 

--- a/src/snap_helpers.py
+++ b/src/snap_helpers.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import tarfile
 from pathlib import Path
 from typing import Optional
 
@@ -11,6 +12,7 @@ from ops.charm import CharmBase
 from config import (
     SNAP_NAME,
     SNAP_SERVICE_NAME,
+    STORAGE_DIR,
     SYSTEMD_OVERRIDE_DIR,
     CVEScannerConfig,
 )
@@ -208,6 +210,41 @@ class CVEScannerSnapManager:
             raise SnapServiceError(
                 f"Failed to check if service {service_name} is active: {err}"
             ) from err
+
+    def extract_osv_db_resource(self, resource_path: Optional[Path]) -> None:
+        """Extract OSV database tarball to STORAGE_DIR if resource is provided.
+
+        Args:
+            resource_path: Path to the osv-db resource file, or None if not attached.
+
+        Raises:
+            SnapConfigurationError: If the tarball is invalid or extraction fails.
+        """
+        if not resource_path or not resource_path.exists():
+            logger.info("No osv-db resource attached, skipping extraction")
+            return
+
+        if resource_path.stat().st_size == 0:
+            logger.info("osv-db resource is empty placeholder, skipping extraction")
+            return
+
+        if not tarfile.is_tarfile(resource_path):
+            raise SnapConfigurationError(
+                f"osv-db resource is not a valid tar archive: {resource_path}"
+            )
+
+        logger.info("Extracting osv-db resource to %s", STORAGE_DIR)
+        try:
+            with tarfile.open(resource_path) as tf:
+                safe_members = [
+                    m for m in tf.getmembers()
+                    if Path(m.name).parts and Path(m.name).parts[0] == "osv-scanner"
+                ]
+                tf.extractall(path=STORAGE_DIR, members=safe_members)
+        except (tarfile.TarError, OSError) as err:
+            raise SnapConfigurationError(f"Failed to extract osv-db resource: {err}") from err
+
+        logger.info("Successfully extracted osv-db resource")
 
     def _install_from_resource(self) -> None:
         """Install the CVE scanner snap from a resource file.

--- a/src/snap_helpers.py
+++ b/src/snap_helpers.py
@@ -236,10 +236,27 @@ class CVEScannerSnapManager:
         logger.info("Extracting osv-db resource to %s", STORAGE_DIR)
         try:
             with tarfile.open(resource_path) as tf:
+                all_members = tf.getmembers()
                 safe_members = [
-                    m for m in tf.getmembers()
+                    m
+                    for m in all_members
                     if Path(m.name).parts and Path(m.name).parts[0] == "osv-scanner"
                 ]
+                skipped = len(all_members) - len(safe_members)
+                if skipped:
+                    logger.warning("Skipped %d tarball entries outside osv-scanner/", skipped)
+                # Normalize ownership to root so the strictly confined snap can read the
+                # extracted files. Otherwise the files is own by ubuntu user by default and
+                # snap cannot read them due to strict confinement.
+                for m in safe_members:
+                    m.uid = 0
+                    m.gid = 0
+                    m.uname = "root"
+                    m.gname = "root"
+                    if m.isdir():
+                        m.mode = 0o755
+                    elif m.isfile():
+                        m.mode = 0o644
                 tf.extractall(path=STORAGE_DIR, members=safe_members)
         except (tarfile.TarError, OSError) as err:
             raise SnapConfigurationError(f"Failed to extract osv-db resource: {err}") from err

--- a/src/snap_helpers.py
+++ b/src/snap_helpers.py
@@ -246,7 +246,7 @@ class CVEScannerSnapManager:
                 if skipped:
                     logger.warning("Skipped %d tarball entries outside osv-scanner/", skipped)
                 # Normalize ownership to root so the strictly confined snap can read the
-                # extracted files. Otherwise the files is own by ubuntu user by default and
+                # extracted files. Otherwise the files are owned by ubuntu user by default and
                 # snap cannot read them due to strict confinement.
                 for m in safe_members:
                     m.uid = 0
@@ -257,7 +257,7 @@ class CVEScannerSnapManager:
                         m.mode = 0o755
                     elif m.isfile():
                         m.mode = 0o644
-                tf.extractall(path=STORAGE_DIR, members=safe_members)
+                tf.extractall(path=STORAGE_DIR, members=safe_members, filter="data")
         except (tarfile.TarError, OSError) as err:
             raise SnapConfigurationError(f"Failed to extract osv-db resource: {err}") from err
 


### PR DESCRIPTION
Follow-up PR for the offline scanning support, as implemented in cve-scanner snap in https://github.com/canonical/cve-scanner/pull/32

This PR adds a charm config to allow switching to offline scanning, and a resource for supplying a raw osv database used in offline scanning. Charm will be blocked if offline mode is enable but the resource is missing. 
Also supports a config to provide the number of threads used for scanning. 

Migrate update status hook's handler to [CollectStatusEvent](https://documentation.ubuntu.com/ops/latest/reference/ops/#ops.CollectStatusEvent) to handle the life cycle cleaner.


Test with [built charm](https://github.com/H-M-Quang-Ngo/cve-scanner-operator/releases/tag/v1.0.1k)

Closes #53 

