### PR TITLE
feat: add grafana-dashboard for cve overview

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -57,7 +57,6 @@ class CVEScannerCharm(CharmBase):
             self,
             refresh_events=[self.on.config_changed, self.on.upgrade_charm],
             scrape_configs=self._scrape_config,
-            metrics_rules_dir="./src/prometheus_alert_rules",
         )
 
     def _get_snap_resource_path(self) -> Optional[Path]:

--- a/src/grafana_dashboards/cve_scanner_overview.json
+++ b/src/grafana_dashboards/cve_scanner_overview.json
@@ -1,0 +1,477 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "CVE vulnerability overview for all Landscape-managed computers",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Failed Nodes",
+      "description": "Number of nodes where the last CVE scan failed",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 1}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "count(cve_scan_success == 0) OR vector(0)",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Total Nodes",
+      "description": "Total number of nodes being scanned",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"fixedColor": "blue", "mode": "fixed"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "blue", "value": null}]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "count(cve_scan_success)",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Collector Status",
+      "description": "CVE collector readiness: Ready = has scan data, Down = no data yet or fatal failure",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {"color": "red", "index": 0, "text": "Down"},
+                "1": {"color": "green", "index": 1, "text": "Ready"}
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "green", "value": 1}
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "cve_collector_ready",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Last Scan Age",
+      "description": "Time elapsed since the last completed CVE scan. Turns red after 3 days.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 259200}
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "time() - cve_last_scan_timestamp",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "row",
+      "title": "CVE Overview",
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 4},
+      "panels": []
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "Computers by CVE Count",
+      "description": "All scanned computers sorted by severity. Click column headers to re-sort.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {"type": "auto"},
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "green", "value": null}]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "Critical"},
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {"type": "color-text"}
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {"color": "text", "value": null},
+                    {"color": "red", "value": 1}
+                  ]
+                }
+              },
+              {"id": "color", "value": {"mode": "thresholds"}}
+            ]
+          },
+          {
+            "matcher": {"id": "byName", "options": "High"},
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {"type": "color-text"}
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {"color": "text", "value": null},
+                    {"color": "orange", "value": 1}
+                  ]
+                }
+              },
+              {"id": "color", "value": {"mode": "thresholds"}}
+            ]
+          },
+          {
+            "matcher": {"id": "byName", "options": "Node"},
+            "properties": [
+              {"id": "custom.width", "value": 300}
+            ]
+          }
+        ]
+      },
+      "gridPos": {"h": 14, "w": 24, "x": 0, "y": 5},
+      "options": {
+        "cellHeight": "sm",
+        "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false},
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": [{"displayName": "Critical", "desc": true}]
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "cve_count{score=\"critical\"} and on(node) (cve_scan_success == 1)",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "cve_count{score=\"high\"} and on(node) (cve_scan_success == 1)",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "cve_count{score=\"medium\"} and on(node) (cve_scan_success == 1)",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "",
+          "refId": "C"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "cve_count{score=\"low\"} and on(node) (cve_scan_success == 1)",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "",
+          "refId": "D"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "cve_count{score=\"unknown\"} and on(node) (cve_scan_success == 1)",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "",
+          "refId": "E"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {"byField": "node", "mode": "outer"}
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "node",
+                "Value #A",
+                "Value #B",
+                "Value #C",
+                "Value #D",
+                "Value #E"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "node": 0,
+              "Value #A": 1,
+              "Value #B": 2,
+              "Value #C": 3,
+              "Value #D": 4,
+              "Value #E": 5
+            },
+            "renameByName": {
+              "node": "Node",
+              "Value #A": "Critical",
+              "Value #B": "High",
+              "Value #C": "Medium",
+              "Value #D": "Low",
+              "Value #E": "Unknown"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Total",
+            "mode": "reduceRow",
+            "reduce": {
+              "include": ["Critical", "High", "Medium", "Low", "Unknown"],
+              "reducer": "sum"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "row",
+      "title": "Scan Failures",
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 19},
+      "panels": []
+    },
+    {
+      "id": 8,
+      "type": "table",
+      "title": "Nodes with Failed Scans",
+      "description": "Nodes reporting a scan error, with the error reason. Sourced from the cve_scan_error metric.",
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {"type": "auto"},
+            "filterable": true,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "green", "value": null}]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "Node"},
+            "properties": [{"id": "custom.width", "value": 300}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "Error Message"},
+            "properties": [
+              {"id": "custom.width", "value": 700},
+              {"id": "custom.cellOptions", "value": {"type": "auto", "wrapText": true}}
+            ]
+          }
+        ]
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 20},
+      "options": {
+        "cellHeight": "sm",
+        "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": false},
+        "showHeader": true,
+        "sortBy": []
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "cve_scan_error",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": ["node", "error"]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "node": 0,
+              "error": 1
+            },
+            "renameByName": {
+              "node": "Node",
+              "error": "Error Message"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 36,
+  "tags": ["cve-scanner"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource",
+        "label": "Datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "CVE Scanner Overview",
+  "uid": "cve-scanner-overview",
+  "version": 1
+}

--- a/src/grafana_dashboards/cve_scanner_overview.json
+++ b/src/grafana_dashboards/cve_scanner_overview.json
@@ -24,7 +24,7 @@
       "type": "stat",
       "title": "Failed Nodes",
       "description": "Number of nodes where the last CVE scan failed",
-      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
@@ -50,7 +50,7 @@
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "expr": "count(cve_scan_success == 0) OR vector(0)",
           "instant": true,
           "legendFormat": "",
@@ -63,7 +63,7 @@
       "type": "stat",
       "title": "Total Nodes",
       "description": "Total number of nodes being scanned",
-      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
       "fieldConfig": {
         "defaults": {
           "color": {"fixedColor": "blue", "mode": "fixed"},
@@ -86,7 +86,7 @@
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "expr": "count(cve_scan_success)",
           "instant": true,
           "legendFormat": "",
@@ -99,7 +99,7 @@
       "type": "stat",
       "title": "Collector Status",
       "description": "CVE collector readiness: Ready = has scan data, Down = no data yet or fatal failure",
-      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
@@ -133,7 +133,7 @@
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "expr": "cve_collector_ready",
           "instant": true,
           "legendFormat": "",
@@ -146,7 +146,7 @@
       "type": "stat",
       "title": "Last Scan Age",
       "description": "Time elapsed since the last completed CVE scan. Turns red after 3 days.",
-      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
       "fieldConfig": {
         "defaults": {
           "color": {"mode": "thresholds"},
@@ -173,7 +173,7 @@
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "expr": "time() - cve_last_scan_timestamp",
           "instant": true,
           "legendFormat": "",
@@ -194,7 +194,7 @@
       "type": "table",
       "title": "Computers by CVE Count",
       "description": "All scanned computers sorted by severity. Click column headers to re-sort.",
-      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -268,7 +268,7 @@
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "expr": "cve_count{score=\"critical\"} and on(node) (cve_scan_success == 1)",
           "instant": true,
           "format": "table",
@@ -276,7 +276,7 @@
           "refId": "A"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "expr": "cve_count{score=\"high\"} and on(node) (cve_scan_success == 1)",
           "instant": true,
           "format": "table",
@@ -284,7 +284,7 @@
           "refId": "B"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "expr": "cve_count{score=\"medium\"} and on(node) (cve_scan_success == 1)",
           "instant": true,
           "format": "table",
@@ -292,7 +292,7 @@
           "refId": "C"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "expr": "cve_count{score=\"low\"} and on(node) (cve_scan_success == 1)",
           "instant": true,
           "format": "table",
@@ -300,7 +300,7 @@
           "refId": "D"
         },
         {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "expr": "cve_count{score=\"unknown\"} and on(node) (cve_scan_success == 1)",
           "instant": true,
           "format": "table",
@@ -376,7 +376,7 @@
       "type": "table",
       "title": "Nodes with Failed Scans",
       "description": "Nodes reporting a scan error, with the error reason. Sourced from the cve_scan_error metric.",
-      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -414,7 +414,7 @@
       },
       "targets": [
         {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "expr": "cve_scan_error",
           "instant": true,
           "format": "table",
@@ -452,21 +452,7 @@
   "schemaVersion": 36,
   "tags": ["cve-scanner"],
   "templating": {
-    "list": [
-      {
-        "current": {},
-        "hide": 0,
-        "includeAll": false,
-        "multi": false,
-        "name": "datasource",
-        "options": [],
-        "query": "prometheus",
-        "refresh": 1,
-        "regex": "",
-        "type": "datasource",
-        "label": "Datasource"
-      }
-    ]
+    "list": []
   },
   "time": {"from": "now-6h", "to": "now"},
   "timepicker": {},


### PR DESCRIPTION
Add a grafana dashboard for an overview of CVE counts across computers:

<img width="1903" height="1074" alt="image" src="https://github.com/user-attachments/assets/b582446e-9b00-4a8c-ad19-960924c45415" />

Tested with [built charm](https://github.com/H-M-Quang-Ngo/cve-scanner-operator/releases/tag/v1.0.1p)

Part of #41
Close #63  