### PR TITLE
feat: forward per-node cve records

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ from ops.charm import ActionEvent, CharmBase, CollectStatusEvent
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError
 
 from cis_manager import CISService, CISServiceError
-from config import CVEScannerConfig
+from config import LOG_SLOT_NAME, SNAP_NAME, CVEScannerConfig
 from cve_scanner import CVEScanner
 from snap_helpers import (
     CVEScannerSnapManager,
@@ -57,6 +57,7 @@ class CVEScannerCharm(CharmBase):
             self,
             refresh_events=[self.on.config_changed, self.on.upgrade_charm],
             scrape_configs=self._scrape_config,
+            log_slots=[f"{SNAP_NAME}:{LOG_SLOT_NAME}"],
         )
 
     def _get_snap_resource_path(self) -> Optional[Path]:

--- a/src/config.py
+++ b/src/config.py
@@ -23,6 +23,11 @@ SERVICE_NAME = f"snap.{SNAP_NAME}.{SNAP_SERVICE_NAME}"
 SYSTEMD_OVERRIDE_DIR = f"/etc/systemd/system/{SERVICE_NAME}.service.d"
 STORAGE_DIR = f"/var/snap/{SNAP_NAME}/common"
 
+# Server-mode findings directory. Match the snap's `logs` content
+# slot source so the shipped files are exposed for tailing.
+LOGS_DIR = f"{STORAGE_DIR}/logs"
+LOG_SLOT_NAME = "logs"
+
 
 class CVEScannerConfig(BaseModel):
     """CVE Scanner charm non-juju secret configuration with validation."""
@@ -180,6 +185,8 @@ class CVEScannerConfig(BaseModel):
             "SCAN_INTERVAL": str(self.scan_interval),  # Already in seconds
             "OSV_OFFLINE": "true" if self.osv_offline else "false",
             "SCAN_THREADS": str(self.scan_threads),
+            # Write server-mode findings into the snap-exposed logs slot directory.
+            "OUTPUT_DIR": LOGS_DIR,
         }
 
         # Add Landscape credentials if available

--- a/src/snap_helpers.py
+++ b/src/snap_helpers.py
@@ -10,6 +10,7 @@ from charmlibs import snap, systemd
 from ops.charm import CharmBase
 
 from config import (
+    LOGS_DIR,
     SNAP_NAME,
     SNAP_SERVICE_NAME,
     STORAGE_DIR,
@@ -124,6 +125,7 @@ class CVEScannerSnapManager:
         Raises:
             SnapConfigurationError: If configuration fails.
         """
+        os.makedirs(LOGS_DIR, exist_ok=True)
         self._setup_ca_certificate(config)
         self._configure_environment(config, charm)
         self._apply_configuration_changes()


### PR DESCRIPTION
Follow-up of https://github.com/canonical/cve-scanner/pull/42

Configure the cve-scanner server to write jsonl files to the snap's logs slot directory, and connect that with corresponding otel-col's plug.

Test with [built charm](https://github.com/H-M-Quang-Ngo/cve-scanner-operator/releases/tag/v1.0.1p) and [built snap](https://github.com/H-M-Quang-Ngo/cve-scanner/releases/tag/v1.1.0.dev2)