### PR TITLE
rework on cve alert rules

### DIFF
--- a/.github/workflows/test_alert_rules.yaml
+++ b/.github/workflows/test_alert_rules.yaml
@@ -1,4 +1,4 @@
-name: Test Prometheus Rules
+name: Test Prometheus and Loki Rules
 
 on:
   workflow_call:
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  promtool:
+  prometheus-alert-rules:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -31,3 +31,21 @@ jobs:
       - name: Run unit tests for prometheus alert rules
         run: |
           promtool test rules tests/unit/test_alert_rules/*.yaml
+
+  loki-alert-rules:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Download lokitool
+      env:
+        LOKITOOL_VERSION: 3.5.3
+      run: |
+        url="https://github.com/grafana/loki/releases/download/v$LOKITOOL_VERSION/lokitool-linux-amd64.zip"
+        wget "$url" -O ./lokitool.zip
+        unzip ./lokitool.zip -d lokitool
+
+    - name: Check validity of loki alert rules
+      run: |
+        ./lokitool/lokitool-linux-amd64 rules check --rule-dirs ./rules/prod/loki

--- a/.github/workflows/test_alert_rules.yaml
+++ b/.github/workflows/test_alert_rules.yaml
@@ -48,4 +48,4 @@ jobs:
 
     - name: Check validity of loki alert rules
       run: |
-        ./lokitool/lokitool-linux-amd64 rules check --rule-dirs ./rules/prod/loki
+        ./lokitool/lokitool-linux-amd64 rules check --rule-dirs ./src/loki_alert_rules

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,12 +7,14 @@ from pathlib import Path
 from typing import Optional
 
 import ops
-from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from ops.charm import ActionEvent, CharmBase, CollectStatusEvent
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError
 
 from cis_manager import CISService, CISServiceError
 from config import LOG_SLOT_NAME, SNAP_NAME, CVEScannerConfig
+
+# Workaround for issue https://github.com/canonical/opentelemetry-collector-operator/issues/303
+from cos_agent_overrides import COSAgentProviderOverride
 from cve_scanner import CVEScanner
 from snap_helpers import (
     CVEScannerSnapManager,
@@ -53,7 +55,7 @@ class CVEScannerCharm(CharmBase):
         self.framework.observe(self.on.secret_changed, self._on_config_changed)
 
         # Initialize COS Agent provider
-        self.cos_agent_provider = COSAgentProvider(
+        self.cos_agent_provider = COSAgentProviderOverride(
             self,
             refresh_events=[self.on.config_changed, self.on.upgrade_charm],
             scrape_configs=self._scrape_config,

--- a/src/cos_agent_overrides.py
+++ b/src/cos_agent_overrides.py
@@ -1,0 +1,29 @@
+"""Local override of COSAgentProvider for log alert rule topology.
+
+Relevant issue: https://github.com/canonical/opentelemetry-collector-operator/issues/303
+Remove this file once the issue is resolved.
+
+"""
+
+from typing import Dict
+
+from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+from cosl import JujuTopology
+from cosl.rules import AlertRules
+
+
+class COSAgentProviderOverride(COSAgentProvider):
+    """COSAgentProvider that omits juju_charm from LogQL alert rule selectors."""
+
+    @property
+    def _log_alert_rules(self) -> Dict:
+        """Build log alert rules with a charm-agnostic topology."""
+        log_topology = JujuTopology(
+            model=self._charm.model.name,
+            model_uuid=self._charm.model.uuid,
+            application=self._charm.model.app.name,
+            unit=self._charm.model.unit.name,
+        )
+        alert_rules = AlertRules(query_type="logql", topology=log_topology)
+        alert_rules.add_path(self._logs_rules, recursive=self._recursive)
+        return alert_rules.as_dict()

--- a/src/loki_alert_rules/cve_findings.yaml
+++ b/src/loki_alert_rules/cve_findings.yaml
@@ -1,0 +1,36 @@
+groups:
+  - name: cve_detailed_findings
+    rules:
+      - alert: CVECriticalSeverityFound
+        expr: |
+          sum by (node, cve_id, package, version) (
+            count_over_time(
+              {filename=~"/snap/opentelemetry-collector/.*/shared-logs/logs/cve_findings_.*.jsonl"}
+                | json
+                | severity = `critical` [8h]
+            )
+          ) > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical CVE {{ $labels.cve_id }} on {{ $labels.node }}"
+          description: >-
+            Critical CVE {{ $labels.cve_id }} found on {{ $labels.node }} in
+            package {{ $labels.package }} {{ $labels.version }}.
+
+      - alert: CVEHighSeverityFound
+        expr: |
+          sum by (node, cve_id, package, version) (
+            count_over_time(
+              {filename=~"/snap/opentelemetry-collector/.*/shared-logs/logs/cve_findings_.*.jsonl"}
+                | json
+                | severity = `high` [8h]
+            )
+          ) > 0
+        labels:
+          severity: warning
+        annotations:
+          summary: "High CVE {{ $labels.cve_id }} on {{ $labels.node }}"
+          description: >-
+            High CVE {{ $labels.cve_id }} found on {{ $labels.node }} in
+            package {{ $labels.package }} {{ $labels.version }}.

--- a/src/prometheus_alert_rules/cve_scanner.yaml
+++ b/src/prometheus_alert_rules/cve_scanner.yaml
@@ -1,131 +1,58 @@
-# NOTE: Current thresholds are examples and should be adjusted based on actual environment and risk tolerance.
 groups:
-  - name: cve_scanner_alerts
+  - name: cve_scanner_general_alerts
     rules:
-      # Critical CVE Alerts
-      - alert: CVECriticalVulnerabilitiesFound
-        expr: sum(cve_count{score="critical"}) > 0
-        labels:
-          severity: critical
-        annotations:
-          summary: "Critical CVE vulnerabilities detected"
-          description: "{{ $value }} critical CVE vulnerabilities found across all scanned nodes"
-
-      # High Severity CVE Alerts
-      - alert: CVEHighVulnerabilitiesThresholdExceeded
-        expr: sum(cve_count{score="high"}) > 20
-        labels:
-          severity: warning
-        annotations:
-          summary: "High number of high-severity CVE vulnerabilities"
-          description: "{{ $value }} high-severity CVE vulnerabilities found across all nodes, exceeding threshold of 20"
-
-      - alert: CVEHighServerAffected
-        expr: count(cve_count{score="high"} > 0) > 5
-        labels:
-          severity: warning
-        annotations:
-          summary: "Multiple servers with high-severity CVE vulnerabilities"
-          description: "{{ $value }} servers have high-severity CVE vulnerabilities"
-
-      # Per-Server CVE Alerts
-      - alert: CVEServerCriticalVulnerabilities
-        expr: cve_count{score="critical"} > 0
-        labels:
-          severity: critical
-          node: "{{ $labels.node }}"
-        annotations:
-          summary: "Critical CVE vulnerabilities on server {{ $labels.node }}"
-          description: "Server {{ $labels.node }} has {{ $value }} critical CVE vulnerabilities"
-
-      - alert: CVEServerHighVulnerabilities
-        expr: cve_count{score="high"} > 10
-        labels:
-          severity: warning
-          node: "{{ $labels.node }}"
-        annotations:
-          summary: "High number of high-severity CVEs on server {{ $labels.node }}"
-          description: "Server {{ $labels.node }} has {{ $value }} high-severity CVE vulnerabilities, exceeding threshold of 10"
-
-      - alert: CVEServerTotalVulnerabilities
-        expr: sum(cve_count{node=~".+"}) by (node) > 50
-        labels:
-          severity: warning
-          node: "{{ $labels.node }}"
-        annotations:
-          summary: "High total CVE count on server {{ $labels.node }}"
-          description: "Server {{ $labels.node }} has {{ $value }} total CVE vulnerabilities, exceeding threshold of 50"
-
-      # CVE Scan Health Alerts
       - alert: CVEScanFailed
-        expr: cve_scan_success == 0
+        expr: cve_scan_error == 1
         for: 10m
         labels:
           severity: warning
-          node: "{{ $labels.node }}"
         annotations:
-          summary: "CVE scan failed on server {{ $labels.node }}"
-          description: "CVE scan has failed on server {{ $labels.node }}"
-
-      - alert: CVEScannerGeneralError
-        expr: cve_scanner_exit_code == 127
-        for: 5m
-        labels:
-          severity: critical
-          node: "{{ $labels.node }}"
-        annotations:
-          summary: "OSV scanner general error"
-          description: |
-            OSV scanner returned a general error on {{ $labels.node }}.
-            This could be a temporal issue with osv-scanner.
-            Try restarting the cve-scanner.exporter service: 'sudo snap restart cve-scanner.cve-exporter'
-            Reference: https://google.github.io/osv-scanner/output/#return-codes
-
-
-      - alert: CVEScannerNoPackagesFound
-        expr: cve_scanner_exit_code == 128
-        for: 5m
-        labels:
-          severity: critical
-          node: "{{ $labels.node }}"
-        annotations:
-          summary: "CVE scanner found no packages on {{ $labels.node }}"
-          description: |
-            OSV scanner returned with no packages found on {{ $labels.node }}. This indicates scanning format not picking up any files to scan.
-            Please open an issue at https://github.com/canonical/cve-scanner/issues
-            Reference: https://google.github.io/osv-scanner/output/#return-codes
+          summary: "CVE scan failed on {{ $labels.node }}"
+          description: >-
+            CVE scan failed on {{ $labels.node }}. Error: {{ $labels.error }}.
+            No vulnerability data is being produced for this node until the next scan
+            (via config-changed hook or manual exporter restart).
+            Run scan-now action for real-time status of this node.
 
       - alert: CVEScanCollectorDown
-        expr: cve_collector_ready == 0
+        expr: cve_collector_ready == 0 and cve_scan_in_progress == 0
         for: 10m
         labels:
           severity: critical
         annotations:
-          summary: "CVE scanner collector is not ready"
-          description: "CVE scanner collector is down or not functioning properly"
+          summary: "CVE collector has no scan data and is not scanning"
+          description: >-
+            The CVE collector is running but has produced no scan data and no scan is in progress.
+            Try restarting the exporter service: 'sudo snap restart cve-scanner.cve-exporter'.
 
       - alert: CVEScanStale
-        expr: (time() - cve_last_scan_timestamp) > 259200  # 3 days
+        expr: (time() - cve_last_scan_timestamp) > 259200
         for: 10m
         labels:
           severity: warning
         annotations:
-          summary: "CVE scan data is stale"
-          description: "Last CVE scan was {{ $value | humanizeDuration }} ago, data may be outdated"
+          summary: "CVE scan data may be stale"
+          description: >-
+            Last CVE scan was {{ $value | humanizeDuration }} ago; data may be outdated.
+            If the scan-interval is configured to be longer, this alert can be ignored.
+            Otherwise, try restarting the exporter service: 'sudo snap restart cve-scanner.cve-exporter'.
 
-      # Health Percentage-based Alerts
-      - alert: CVETotalCriticalPercentage
-        expr: (count(cve_count{score="critical"} > 0) / count(count(cve_count) by (node))) * 100 > 10
+      # Cluster-wide summary (info only, not actionable on its own)
+      # Fires when the cluster has any failed scan, any critical or high CVE.
+      - alert: CVEClusterWideSummary
+        expr: >-
+          (count(cve_scan_error == 1) or vector(0))
+          + (count(cve_count{score="critical"} > 0) or vector(0))
+          + (count(cve_count{score="high"} > 0) or vector(0))
+          > 0
         labels:
-          severity: critical
+          severity: info
         annotations:
-          summary: "High percentage of scanned computers has critical CVE vulnerabilities"
-          description: "{{ $value | printf \"%.1f\" }}% of scanned computers has critical CVE vulnerabilities ({{ with query \"count(cve_count{score=\\\"critical\\\"} > 0)\" }}{{ . | first | value }}{{ end }} out of {{ with query \"count(count(cve_count) by (node))\" }}{{ . | first | value }}{{ end }} servers)"
-
-      - alert: CVETotalHighPercentage
-        expr: (count(cve_count{score="high"} > 0) / count(count(cve_count) by (node))) * 100 > 30
-        labels:
-          severity: warning
-        annotations:
-          summary: "High percentage of scanned computers has high-severity CVE vulnerabilities"
-          description: "{{ $value | printf \"%.1f\" }}% of scanned computers has high-severity CVE vulnerabilities ({{ with query \"count(cve_count{score=\\\"high\\\"} > 0)\" }}{{ . | first | value }}{{ end }} out of {{ with query \"count(count(cve_count) by (node))\" }}{{ . | first | value }}{{ end }} servers)"
+          summary: >-
+            Cluster: {{ with query "count(cve_scan_success == 0)" }}{{ . | first | value | printf "%.0f" }}{{ else }}0{{ end }}/{{ with query "count(cve_scan_success)" }}{{ . | first | value | printf "%.0f" }}{{ else }}0{{ end }} failed scan(s);
+            {{ with query "count(cve_count{score=\"critical\"} > 0)" }}{{ . | first | value | printf "%.0f" }}{{ else }}0{{ end }} node(s) with critical CVEs;
+            {{ with query "count(cve_count{score=\"high\"} > 0)" }}{{ . | first | value | printf "%.0f" }}{{ else }}0{{ end }} node(s) with high CVEs
+          description: >-
+            Failed-scan node(s): {{ range query "cve_scan_success == 0" }}{{ .Labels.node }} {{ else }}(none){{ end }}.
+            Node(s) with critical CVEs: {{ range query "cve_count{score=\"critical\"} > 0" }}{{ .Labels.node }} {{ else }}(none){{ end }}.
+            Node(s) with high CVEs: {{ range query "cve_count{score=\"high\"} > 0" }}{{ .Labels.node }} {{ else }}(none){{ end }}.

--- a/tests/unit/test_alert_rules/test_cve_scanner.yaml
+++ b/tests/unit/test_alert_rules/test_cve_scanner.yaml
@@ -1,308 +1,122 @@
 rule_files:
   - ../../../src/prometheus_alert_rules/cve_scanner.yaml
 
-evaluation_interval: 2m
+evaluation_interval: 1m
 
 tests:
   - interval: 1m
     input_series:
-      - series: cve_count{node="N1",score="critical"}
-        values: '0 0 5 5 5'
-      - series: cve_count{node="N2",score="critical"}
-        values: '0 0 3 3 3'
-      - series: cve_count{node="N1",score="high"}
-        values: '2 2 2 2 2'
-      - series: cve_count{node="N2",score="high"}
-        values: '1 1 1 1 1'
+      - series: cve_scan_error{node="N1",error="boom"}
+        values: '1 1 1 1 1 1 1 1 1 1 1'  # t=0..10m
+      - series: cve_scan_success{node="N2"}
+        values: '1 1 1 1 1 1 1 1 1 1 1'
 
     alert_rule_test:
-      - eval_time: 0m
-        alertname: CVECriticalVulnerabilitiesFound
+      - eval_time: 9m
+        alertname: CVEScanFailed
         exp_alerts: []
 
-      - eval_time: 2m
-        alertname: CVECriticalVulnerabilitiesFound
+      - eval_time: 10m
+        alertname: CVEScanFailed
         exp_alerts:
           - exp_labels:
-              severity: critical
-            exp_annotations:
-              summary: "Critical CVE vulnerabilities detected"
-              description: "8 critical CVE vulnerabilities found across all scanned nodes"
-
-      - eval_time: 2m
-        alertname: CVEServerCriticalVulnerabilities
-        exp_alerts:
-          - exp_labels:
-              severity: critical
+              severity: warning
               node: N1
-              score: critical
+              error: boom
             exp_annotations:
-              summary: "Critical CVE vulnerabilities on server N1"
-              description: "Server N1 has 5 critical CVE vulnerabilities"
-          - exp_labels:
-              severity: critical
-              node: N2
-              score: critical
-            exp_annotations:
-              summary: "Critical CVE vulnerabilities on server N2"
-              description: "Server N2 has 3 critical CVE vulnerabilities"
+              summary: "CVE scan failed on N1"
+              description: >-
+                CVE scan failed on N1. Error: boom.
+                No vulnerability data is being produced for this node until the next scan
+                (via config-changed hook or manual exporter restart).
+                Run scan-now action for real-time status of this node.
 
   - interval: 1m
     input_series:
-      - series: cve_count{node="N1",score="high"}
-        values: '5 10 25 25 25'
-      - series: cve_count{node="N2",score="high"}
-        values: '3 5 15 15 15'
+      - series: cve_collector_ready
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+      - series: cve_scan_in_progress
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: CVEScanCollectorDown
+        exp_alerts: []
+
+      - eval_time: 10m
+        alertname: CVEScanCollectorDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              summary: "CVE collector has no scan data and is not scanning"
+              description: >-
+                The CVE collector is running but has produced no scan data and no scan is in progress.
+                Try restarting the exporter service: 'sudo snap restart cve-scanner.cve-exporter'.
+
+  # long-running scan must not trigger false positives.
+  - interval: 1m
+    input_series:
+      - series: cve_collector_ready
+        values: '0 0 0 0 0 0 0 0 0 0 0 0 0'  # t=0..12m
+      - series: cve_scan_in_progress
+        values: '1 1 1 1 1 1 1 1 1 1 1 1 1'  # scan running
+
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: CVEScanCollectorDown
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: cve_last_scan_timestamp
+        values: '0+0x4331'  # t=0..4331m, in days: 0..3d 0h 11m
+
+    alert_rule_test:
+      - eval_time: 4330m
+        alertname: CVEScanStale
+        exp_alerts: []
+
+      - eval_time: 4331m
+        alertname: CVEScanStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "CVE scan data may be stale"
+              description: >-
+                Last CVE scan was 3d 0h 11m 0s ago; data may be outdated.
+                If the scan-interval is configured to be longer, this alert can be ignored.
+                Otherwise, try restarting the exporter service: 'sudo snap restart cve-scanner.cve-exporter'.
+
+  - interval: 1m
+    input_series:
+      - series: cve_scan_error{node="N1",error="oops"}
+        values: '1 1 1'
+      - series: cve_scan_success{node="N1"}
+        values: '0 0 0'
+      - series: cve_scan_success{node="N2"}
+        values: '1 1 1'
+      - series: cve_scan_success{node="N3"}
+        values: '1 1 1'
+      - series: cve_scan_success{node="N4"}
+        values: '1 1 1'
+      - series: cve_count{node="N2",score="critical"}
+        values: '5 5 5'
       - series: cve_count{node="N3",score="high"}
-        values: '2 3 5 5 5'
+        values: '3 3 3'
+      - series: cve_count{node="N4",score="high"}
+        values: '3 3 3'
 
     alert_rule_test:
       - eval_time: 1m
-        alertname: CVEHighVulnerabilitiesThresholdExceeded
-        exp_alerts: []
-
-      - eval_time: 2m
-        alertname: CVEHighVulnerabilitiesThresholdExceeded
+        alertname: CVEClusterWideSummary
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: info
             exp_annotations:
-              summary: "High number of high-severity CVE vulnerabilities"
-              description: "45 high-severity CVE vulnerabilities found across all nodes, exceeding threshold of 20"
-
-      - eval_time: 2m
-        alertname: CVEServerHighVulnerabilities
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              node: N1
-              score: high
-            exp_annotations:
-              summary: "High number of high-severity CVEs on server N1"
-              description: "Server N1 has 25 high-severity CVE vulnerabilities, exceeding threshold of 10"
-          - exp_labels:
-              severity: warning
-              node: N2
-              score: high
-            exp_annotations:
-              summary: "High number of high-severity CVEs on server N2"
-              description: "Server N2 has 15 high-severity CVE vulnerabilities, exceeding threshold of 10"
-
-  - interval: 1m
-    input_series:
-      - series: cve_count{node="N1",score="critical"}
-        values: '10 10 10'
-      - series: cve_count{node="N1",score="high"}
-        values: '15 15 15'
-      - series: cve_count{node="N1",score="medium"}
-        values: '20 20 20'
-      - series: cve_count{node="N1",score="low"}
-        values: '10 10 10'
-      - series: cve_count{node="N1",score="unknown"}
-        values: '5 5 5'
-      - series: cve_count{node="N2",score="critical"}
-        values: '2 2 2'
-      - series: cve_count{node="N2",score="high"}
-        values: '5 5 5'
-      - series: cve_count{node="N2",score="medium"}
-        values: '10 10 10'
-      - series: cve_count{node="N2",score="low"}
-        values: '8 8 8'
-      - series: cve_count{node="N2",score="unknown"}
-        values: '2 2 2'
-
-    alert_rule_test:
-      - eval_time: 0m
-        alertname: CVEServerTotalVulnerabilities
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              node: N1
-            exp_annotations:
-              summary: "High total CVE count on server N1"
-              description: "Server N1 has 60 total CVE vulnerabilities, exceeding threshold of 50"
-
-  - interval: 2m
-    input_series:
-      - series: cve_scan_success{node="N1"}
-        values: '1 0 0 0 0 0 0'
-      - series: cve_scan_success{node="N2"}
-        values: '1 1 1 1 1 1 1'
-
-    alert_rule_test:
-      - eval_time: 8m
-        alertname: CVEScanFailed
-        exp_alerts: []
-
-      - eval_time: 12m
-        alertname: CVEScanFailed
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              node: N1
-            exp_annotations:
-              summary: "CVE scan failed on server N1"
-              description: "CVE scan has failed on server N1"
-
-  - interval: 2m
-    input_series:
-      - series: cve_scanner_exit_code{node="N1"}
-        values: '127 127 127 127'
-      - series: cve_scanner_exit_code{node="N2"}
-        values: '128 128 128 128'
-
-    alert_rule_test:
-      - eval_time: 4m
-        alertname: CVEScannerGeneralError
-        exp_alerts: []
-
-      - eval_time: 6m
-        alertname: CVEScannerGeneralError
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              node: N1
-            exp_annotations:
-              summary: "OSV scanner general error"
-              description: |
-                OSV scanner returned a general error on N1.
-                This could be a temporal issue with osv-scanner.
-                Try restarting the cve-scanner.exporter service: 'sudo snap restart cve-scanner.cve-exporter'
-                Reference: https://google.github.io/osv-scanner/output/#return-codes
-
-      - eval_time: 6m
-        alertname: CVEScannerNoPackagesFound
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-              node: N2
-            exp_annotations:
-              summary: "CVE scanner found no packages on N2"
-              description: |
-                OSV scanner returned with no packages found on N2. This indicates scanning format not picking up any files to scan.
-                Please open an issue at https://github.com/canonical/cve-scanner/issues
-                Reference: https://google.github.io/osv-scanner/output/#return-codes
-
-  - interval: 2m
-    input_series:
-      - series: cve_collector_ready
-        values: '1 0 0 0 0 0 0'
-
-    alert_rule_test:
-      - eval_time: 8m
-        alertname: CVEScanCollectorDown
-        exp_alerts: []
-
-      - eval_time: 12m
-        alertname: CVEScanCollectorDown
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-            exp_annotations:
-              summary: "CVE scanner collector is not ready"
-              description: "CVE scanner collector is down or not functioning properly"
-
-  - interval: 1m
-    input_series:
-      - series: cve_count{node="N1",score="critical"}
-        values: '0 0 5 5 5'
-      - series: cve_count{node="N2",score="critical"}
-        values: '0 0 0 0 0'
-      - series: cve_count{node="N3",score="critical"}
-        values: '0 0 0 0 0'
-      - series: cve_count{node="N1",score="high"}
-        values: '5 5 5 5 5'
-      - series: cve_count{node="N2",score="high"}
-        values: '3 3 3 3 3'
-      - series: cve_count{node="N3",score="high"}
-        values: '0 0 0 0 0'
-      - series: cve_count{node="N1",score="medium"}
-        values: '1 1 1 1 1'
-      - series: cve_count{node="N2",score="medium"}
-        values: '1 1 1 1 1'
-      - series: cve_count{node="N3",score="medium"}
-        values: '1 1 1 1 1'
-
-    alert_rule_test:
-      - eval_time: 0m
-        alertname: CVETotalCriticalPercentage
-        exp_alerts: []
-
-      - eval_time: 2m
-        alertname: CVETotalCriticalPercentage
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-            exp_annotations:
-              summary: "High percentage of scanned computers has critical CVE vulnerabilities"
-              description: "33.3% of scanned computers has critical CVE vulnerabilities (1 out of 3 servers)"
-
-      - eval_time: 2m
-        alertname: CVETotalHighPercentage
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-            exp_annotations:
-              summary: "High percentage of scanned computers has high-severity CVE vulnerabilities"
-              description: "66.7% of scanned computers has high-severity CVE vulnerabilities (2 out of 3 servers)"
-
-  - interval: 1m
-    input_series:
-      - series: cve_count{node="N1",score="critical"}
-        values: '0 0 0'
-      - series: cve_count{node="N1",score="high"}
-        values: '1 1 1'
-      - series: cve_count{node="N1",score="medium"}
-        values: '20 20 20'
-      - series: cve_count{node="N1",score="low"}
-        values: '20 20 20'
-      - series: cve_count{node="N1",score="unknown"}
-        values: '2 2 2'
-      - series: cve_count{node="N2",score="critical"}
-        values: '0 0 0'
-      - series: cve_count{node="N2",score="high"}
-        values: '1 1 1'
-      - series: cve_count{node="N2",score="medium"}
-        values: '20 20 20'
-      - series: cve_count{node="N2",score="low"}
-        values: '20 20 20'
-      - series: cve_count{node="N2",score="unknown"}
-        values: '2 2 2'
-      - series: cve_count{node="N3",score="critical"}
-        values: '0 0 0'
-      - series: cve_count{node="N3",score="high"}
-        values: '4 4 4'
-      - series: cve_count{node="N3",score="medium"}
-        values: '45 45 45'
-      - series: cve_count{node="N3",score="low"}
-        values: '37 37 37'
-      - series: cve_count{node="N3",score="unknown"}
-        values: '4 4 4'
-
-    alert_rule_test:
-      - eval_time: 0m
-        alertname: CVEServerTotalVulnerabilities
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              node: N3
-            exp_annotations:
-              summary: "High total CVE count on server N3"
-              description: "Server N3 has 90 total CVE vulnerabilities, exceeding threshold of 50"
-
-      - eval_time: 0m
-        alertname: CVETotalHighPercentage
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-            exp_annotations:
-              summary: "High percentage of scanned computers has high-severity CVE vulnerabilities"
-              description: "100.0% of scanned computers has high-severity CVE vulnerabilities (3 out of 3 servers)"
-
-      - eval_time: 0m
-        alertname: CVEHighVulnerabilitiesThresholdExceeded
-        exp_alerts: []
-
-      - eval_time: 0m
-        alertname: CVECriticalVulnerabilitiesFound
-        exp_alerts: []
+              summary: "Cluster: 1/4 failed scan(s); 1 node(s) with critical CVEs; 2 node(s) with high CVEs"
+              description: >-
+                Failed-scan node(s): N1 .
+                Node(s) with critical CVEs: N2 .
+                Node(s) with high CVEs: N3 N4 .

--- a/tests/unit/test_alert_rules/test_cve_scanner.yaml
+++ b/tests/unit/test_alert_rules/test_cve_scanner.yaml
@@ -99,13 +99,9 @@ tests:
         values: '1 1 1'
       - series: cve_scan_success{node="N3"}
         values: '1 1 1'
-      - series: cve_scan_success{node="N4"}
-        values: '1 1 1'
       - series: cve_count{node="N2",score="critical"}
         values: '5 5 5'
       - series: cve_count{node="N3",score="high"}
-        values: '3 3 3'
-      - series: cve_count{node="N4",score="high"}
         values: '3 3 3'
 
     alert_rule_test:
@@ -115,8 +111,8 @@ tests:
           - exp_labels:
               severity: info
             exp_annotations:
-              summary: "Cluster: 1/4 failed scan(s); 1 node(s) with critical CVEs; 2 node(s) with high CVEs"
+              summary: "Cluster: 1/3 failed scan(s); 1 node(s) with critical CVEs; 1 node(s) with high CVEs"
               description: >-
                 Failed-scan node(s): N1 .
                 Node(s) with critical CVEs: N2 .
-                Node(s) with high CVEs: N3 N4 .
+                Node(s) with high CVEs: N3 .


### PR DESCRIPTION
Rework on CVE alert rules:
- Remove Prometheus rules for cluster-wide CVE counts. Add an info alert.
- Add Loki rules for each high & critical CVE found in each node. 

Close #67  

Add a workaround for COSAgentProvider due to https://github.com/canonical/opentelemetry-collector-operator/issues/303